### PR TITLE
Fix an alignment bug causing us to send very small packets

### DIFF
--- a/rpc/block_write_stream.go
+++ b/rpc/block_write_stream.go
@@ -173,9 +173,9 @@ func (s *blockWriteStream) makePacket() outboundPacket {
 	// gets unhappy unless we first align to a chunk boundary with a small packet.
 	// Otherwise it yells at us with "a partial chunk must be sent in an
 	// individual packet" or just complains about a corrupted block.
-	alignment := outboundChunkSize - (int(s.offset) % outboundChunkSize)
-	if alignment > 0 && alignment < packetLength {
-		packetLength = alignment
+	alignment := int(s.offset) % outboundChunkSize
+	if alignment > 0 && packetLength > (outboundChunkSize-alignment) {
+		packetLength = outboundChunkSize - alignment
 	}
 
 	numChunks := int(math.Ceil(float64(packetLength) / float64(outboundChunkSize)))

--- a/rpc/block_writer_test.go
+++ b/rpc/block_writer_test.go
@@ -99,3 +99,29 @@ func TestWriteFailsOver(t *testing.T) {
 	assert.EqualValues(t, 1048576, n)
 	assert.EqualValues(t, 0xb35a6a0e, hash.Sum32())
 }
+
+func TestPacketSize(t *testing.T) {
+	bws := &blockWriteStream{}
+	bws.buf.Write(make([]byte, outboundPacketSize*3))
+	packet := bws.makePacket()
+
+	assert.EqualValues(t, outboundPacketSize, len(packet.data))
+}
+
+func TestPacketSizeUndersize(t *testing.T) {
+	bws := &blockWriteStream{}
+	bws.buf.Write(make([]byte, outboundPacketSize-5))
+	packet := bws.makePacket()
+
+	assert.EqualValues(t, outboundPacketSize-5, len(packet.data))
+}
+
+func TestPacketSizeAlignment(t *testing.T) {
+	bws := &blockWriteStream{}
+	bws.buf.Write(make([]byte, outboundPacketSize*3))
+
+	bws.offset = 5
+	packet := bws.makePacket()
+
+	assert.EqualValues(t, outboundChunkSize-5, len(packet.data))
+}


### PR DESCRIPTION
The faulty math in block_write_stream was causing us to always send
512 byte packets.